### PR TITLE
Attempt to fix #23

### DIFF
--- a/gofile.py
+++ b/gofile.py
@@ -1,17 +1,34 @@
+import json
+import shlex
 import requests
+import subprocess
+
 
 def uploadFile(file, token=None, folderId=None):
     
     server = requests.get("https://api.gofile.io/getServer").json()["data"]["server"]
-    
-    response = requests.post(
-        url=f"https://{server}.gofile.io/uploadFile",
-        data={
-            "token": token,
-            "folderId": folderId
-        },
-        files={"upload_file": open(file, "rb")}
-    ).json()
+
+    upload_cmd = shlex.split(
+        'curl '
+        f'-F file=@{file} '
+        f'-F token={token} '
+        f'-F folderId={folderId} '
+        f'https://{server}.gofile.io/uploadFile'
+    )
+    try:
+        out = subprocess.check_output(upload_cmd, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        raise Exception(e)
+    out = out.decode("UTF-8").strip()
+    if out:
+        try:
+            response = json.loads(out)
+        except:
+            raise Exception("API Error (Not Vaild JSON Data Received)")
+        if not response:
+            raise Exception("API Error (No JSON Data Received)")
+    else:
+        raise Exception("API Error (No Data Received)")
     
     if response["status"] == "ok":
         data = response["data"]


### PR DESCRIPTION
When you `open(file, "rb")` it stores binary data on RAM. Means 1GB file data will be stored on RAM till you `close()`.

But if you use curl with subprocess, curl will handle it properly.

But still you should give it a test before merging.